### PR TITLE
Fixes array of arrays and duplicates

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -129,6 +129,7 @@ module.exports.create = function (Model, fixtures, opts, sails) {
     //actual creation in case of empty collection
     return addAssociation(Model, fixtures, sails)
     .then(function (populatedFixtures) {
+      populatedFixtures = _.uniq(_.flatten(populatedFixtures, true), 'id');
       //sails.log.debug(populatedFixtures);
       return Model.create(populatedFixtures);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-fixtures",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Automatically install database fixtures with relations to your database when you lift Sails",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Sometimes when using fixtures for some reason the populatedFixtures array came with several arrays and sub arrays, and duplicate objects inside the array.