### PR TITLE
Fixed duplicate issue when fixture has fixed 'id' and both 'models' and 'collections'. Added unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+nbproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "0.10"
 services:
   - mongodb
+before_install: npm install -g grunt-cli

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,8 @@ function emptyExistingCollections (opts, sails) {
       sails.log.info('Undefined model for emptying: `' + name + '`');
       return;
     }
+    //add the fixture name to options for easy access
+    opts.model_name = name;
     return util.empty(Model, opts, sails);
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+/* global Promise */
+
 /**
  * Some code adapted from a permissions-hook in the making:
  * https://github.com/tjwebb/sails-permissions/blob/master/api/hooks/permissions-api/index.js#L26

--- a/lib/util.js
+++ b/lib/util.js
@@ -136,7 +136,7 @@ module.exports.create = function (Model, fixtures, opts, sails) {
 };
 
 module.exports.empty = function (Model, opts, sails) {
-  if (_.contains(opts.emtpy, opts.model_name)) {
+  if (_.contains(opts.empty, opts.model_name)) {
     return Model.find()
     .then(function (results) {
       sails.log.info('Removing existing documents from ' + opts.model_name);

--- a/lib/util.js
+++ b/lib/util.js
@@ -140,8 +140,14 @@ module.exports.empty = function (Model, opts, sails) {
   if (_.contains(opts.empty, opts.model_name)) {
     return Model.find()
     .then(function (results) {
-      sails.log.info('Removing existing documents from ' + model_name);
-      return Model.destroy({id: _.pluck(results, 'id')});
+      if (results.length > 0) {
+        sails.log.info('Removing existing documents from ' + model_name);
+        return Model.destroy({id: _.pluck(results, 'id')});
+      }
+      else {
+        //just resolve
+        return Promise.resolve();
+      }
     });
   }
   else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -69,8 +69,7 @@ function addModels (Model, seed, sails) {
   //sails.log.debug(modelkeys);
   var props = {};
   _.each(modelkeys, function (key) {
-    var alias = getAlias(Model, key, sails);
-    props[key] = findAssociationIds(seed, alias, seed.models[key], sails, true);
+    props[key] = findAssociationIds(seed, getAlias(Model, key), seed.models[key], sails, true);
   });
   return Promise.props(props)
   .then(function (modelsobj) {
@@ -91,10 +90,10 @@ function addAssociation (Model, seeds, sails) {
     }
     if (seed.collections && seed.models) {
       //both are present
-      return Promise.join(addCollections(Model, seed, sails), addModels(Model, seed, sails))
-      .then(function (collectionSeed, modelSeed) {
-        return _.merge(collectionSeed, modelSeed);
-      });
+      return addCollections(Model, seed, sails)
+        .then(function (seedWithCollections) {
+          return addModels(Model, seedWithCollections, sails);
+        });
     }
     else if (!seed.collections && seed.models) {
       //only model
@@ -104,17 +103,6 @@ function addAssociation (Model, seeds, sails) {
       //only collections
       return addCollections(Model, seed, sails);
     }
-  });
-}
-
-function removeDuplicates(arrayToAnalyze) {
-  return _.filter(arrayToAnalyze, function(element, index) {
-    for (index += 1; index < arrayToAnalyze.length; index += 1) {
-      if (_.isEqual(element, arrayToAnalyze[index])) {
-        return false;
-      }
-    }
-    return true;
   });
 }
 
@@ -141,7 +129,6 @@ module.exports.create = function (Model, fixtures, opts, sails) {
     return addAssociation(Model, fixtures, sails)
     .then(function (populatedFixtures) {
       //sails.log.debug('result of population: ');
-      populatedFixtures = removeDuplicates(_.flatten(populatedFixtures, true));
       //sails.log.debug(populatedFixtures);
       return Model.create(populatedFixtures);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-fixtures",
-  "version": "0.11.4",
+  "version": "0.11.4.1",
   "description": "Automatically install database fixtures with relations to your database when you lift Sails",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -28,19 +28,19 @@
   },
   "homepage": "https://github.com/arryon/sails-hook-fixtures",
   "dependencies": {
-    "bluebird": "~2.9.9",
-    "lodash": "3.0.0"
+    "bluebird": "~2.10.2",
+    "lodash": "~3.10.0"
   },
   "devDependencies": {
-    "bcryptjs": "~2.1.0",
+    "bcryptjs": "~2.3.0",
     "grunt": "~0.4.5",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "^0.12.7",
     "mocha": "^2.1.0",
     "sails": "~0.11.0",
-    "sails-mongo": "^0.10.5",
-    "should": "^5.0.0",
-    "should-promised": "0.0.5"
+    "sails-mongo": "~0.11.4",
+    "should": "~7.1.0",
+    "should-promised": "0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-fixtures",
-  "version": "0.11.4.1",
+  "version": "0.11.5",
   "description": "Automatically install database fixtures with relations to your database when you lift Sails",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "hook"
   ],
   "author": "Arryon Tijsma",
+  "contributors": [
+    {
+      "name": "Luis Lobo Borobia",
+      "email": "luislobo@gmail.com"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/arryon/sails-hook-fixtures/issues"

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -60,7 +60,7 @@ describe('Test without fixtures ::', function () {
       },
       log: {
         level: 'error'
-      },
+      }
     }, function (err, _sails) {
       if (err) { return done(err); }
       sails = _sails;
@@ -77,6 +77,6 @@ describe('Test without fixtures ::', function () {
   });
 
   it('should not crash when there are no fixtures', function (done) {
-    return done()
+    return done();
   });
 });

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,5 +1,5 @@
 module.exports = {
-  order: ['Hometown', 'User','Pet', 'Group', 'Role'],
+  order: ['Hometown', 'User', 'Pet', 'Group', 'Role', 'Company'],
   overwrite: ['User'],
   User: [
     {
@@ -24,7 +24,7 @@ module.exports = {
     {
       name: 'admin',
       collections: {
-        user: {username: 'admin'},
+        user: {username: 'admin'}
       }
     },
     {
@@ -44,7 +44,7 @@ module.exports = {
     {
       name: 'Admin group',
       collections: {
-        user: {username: ['admin']},
+        user: {username: ['admin']}
       }
     },
     {
@@ -58,7 +58,28 @@ module.exports = {
     {
       name: 'Pikachu',
       models: {
-       owner: {username: 'Ash Ketchum'}
+        owner: {username: 'Ash Ketchum'}
+      }
+    }
+  ],
+  Company: [
+    {
+      name: 'Sweet & Co',
+      models: {
+        hometown: ['Pallet Town']
+      },
+      collections: {
+        group: ['Admin group', 'Ordinary group']
+      }
+    },
+    {
+      id: '56ff2dcde7db1b663d0ae57e',
+      name: 'Nice & Co',
+      models: {
+        hometown: ['Pallet Town']
+      },
+      collections: {
+        group: ['Admin group', 'Ordinary group']
       }
     }
   ]

--- a/test/helpers/sampleApp/api/models/Company.js
+++ b/test/helpers/sampleApp/api/models/Company.js
@@ -1,0 +1,17 @@
+module.exports = {
+  attributes: {
+    name: {
+      type: 'string',
+      required: true
+    },
+    companyGroups: {
+      collection: 'group',
+      via: 'company',
+      dominant: true
+    },
+    hometown: {
+      model: 'hometown',
+      required: true
+    }
+  }
+};

--- a/test/helpers/sampleApp/api/models/Group.js
+++ b/test/helpers/sampleApp/api/models/Group.js
@@ -23,5 +23,11 @@ module.exports = {
       collection: 'role',
       via: 'groups'
     },
+    
+    /* A company  */
+    company:{
+      collection: 'company',
+      via: 'companyGroups'
+    }
   }
 };

--- a/test/sampleApp.spec.js
+++ b/test/sampleApp.spec.js
@@ -42,7 +42,7 @@ function loadSails (done, fixtures) {
     },
     models: {
       connection: 'test',
-      migrate: 'drop'
+      migrate: 'drop',
     },
     fixtures: fixtures
   }, function (err, _sails) {
@@ -125,6 +125,15 @@ describe('Test with models ::', function () {
     Role.find()
     .then(function (results) {
       results.should.have.length(3);
+      done();
+    }).catch(done);
+  });
+  
+  it('Should have made two company documents', function (done) {
+    var Company = sails.models.company;
+    Company.find()
+    .then(function (results) {
+      results.should.have.length(2);
       done();
     }).catch(done);
   });

--- a/test/sampleApp.spec.js
+++ b/test/sampleApp.spec.js
@@ -27,7 +27,7 @@ function loadSails (done, fixtures) {
       'fixtures': require('../lib'),
       'grunt': false,
       'views': false,
-      'blueprints': false,
+      'blueprints': false
     },
     log: {
       level: 'info'
@@ -38,11 +38,11 @@ function loadSails (done, fixtures) {
         host:'localhost',
         port: 27017,
         database: 'sails-hook-fixtures-testdb'
-      },
+      }
     },
     models: {
       connection: 'test',
-      migrate: 'drop',
+      migrate: 'drop'
     },
     fixtures: fixtures
   }, function (err, _sails) {
@@ -69,11 +69,6 @@ function lowerSails (done) {
   return done();
 }
 
-function reloadSails (done) {
-  lowerSails(function () {
-    loadSails(done);
-  });
-}
 describe('Test with one empty fixture :: ', function () {
   before(function(done) {
     var fixtures = _.cloneDeep(require('./helpers/fixtures'));
@@ -88,7 +83,7 @@ describe('Test with one empty fixture :: ', function () {
   it('Should disregard an empty fixture array', function (done) {
     return done();
   });
-})
+});
 
 describe('Test with models ::', function () {
   //before, lift sails


### PR DESCRIPTION
* Fixed duplicate issue when fixture has fixed 'id' and both 'models' and 'collections'. 
* Added fixture and unit test for fixtures with both 'models' and 'collections: ```Company``` model.
* Cleaned up code based on jshint suggestions.
* Replaced Promise.join call as it was not correctly used (it should have had a function call as a third parameter) but anyway, as seed is passed by reference, there was no need to actually process the result, as the seed object was being changed inside each promise. Replaced with chained thens', as it also optimizes time since it does not need the _.merge.
