### PR TITLE
Updated for Sails 1.0

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -130,7 +130,7 @@ module.exports.create = function (Model, fixtures, opts, sails) {
     .then(function (populatedFixtures) {
       //sails.log.debug('result of population: ');
       //sails.log.debug(populatedFixtures);
-      return Model.create(populatedFixtures);
+      return Model.createEach(populatedFixtures);
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-fixtures",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Automatically install database fixtures with relations to your database when you lift Sails",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Uses createEach() instead of create() for adding new records to the database.